### PR TITLE
docs: add placeholder drafts for upcoming articles

### DIFF
--- a/_drafts/agent-skills-i-like-using.md
+++ b/_drafts/agent-skills-i-like-using.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "The agent skills I actually like using"
+tags   : [AI, Software, Tooling]
+---
+
+A tour of the skills, tools, and capabilities I enable for my coding agent, and
+which ones I keep disabled.

--- a/_drafts/automating-boring-tasks.md
+++ b/_drafts/automating-boring-tasks.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "Automating boring tasks with shell scripts and Makefiles"
+tags   : [Linux, Shell, Tooling]
+---
+
+How I stop repeating myself: scripts and Makefiles for the chores that used to
+waste my time.

--- a/_drafts/browser-extensions-that-respect-privacy.md
+++ b/_drafts/browser-extensions-that-respect-privacy.md
@@ -1,0 +1,7 @@
+---
+layout : post
+title  : "Browser extensions that respect your privacy"
+tags   : [Web, Privacy]
+---
+
+The extensions I trust and use, and the ones I avoid.

--- a/_drafts/firefox-customization-part-2.md
+++ b/_drafts/firefox-customization-part-2.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "Firefox customization, part 2: userChrome.css"
+tags   : [Web, Software, Privacy]
+---
+
+A deeper dive into Firefox customization with userChrome.css examples, following
+up on the earlier Firefox post.

--- a/_drafts/five-years-in-linux.md
+++ b/_drafts/five-years-in-linux.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "Five years in Linux: revisiting Two Years in Linux"
+tags   : [Linux]
+---
+
+A retrospective on the original "Two Years in Linux" post, updated with what
+changed over the following years.

--- a/_drafts/how-i-use-an-agent-day-to-day.md
+++ b/_drafts/how-i-use-an-agent-day-to-day.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "How I use a coding agent day to day"
+tags   : [AI, Software, Tooling]
+---
+
+A realistic walkthrough of a session with my agent: from prompt to a reviewed,
+committed change, including where it shines and where it trips up.

--- a/_drafts/lessons-from-10-years-of-r.md
+++ b/_drafts/lessons-from-10-years-of-r.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "Lessons from 10 years of R"
+tags   : [R, Data Science]
+---
+
+What a decade of R taught me about statistics, coding, and tooling. Advice I
+would give my younger self.

--- a/_drafts/my-dotfiles-setup.md
+++ b/_drafts/my-dotfiles-setup.md
@@ -1,0 +1,7 @@
+---
+layout : post
+title  : "My dotfiles setup and how I manage them"
+tags   : [Linux, Tooling]
+---
+
+How I structure, version, and sync my dotfiles across machines.

--- a/_drafts/my-python-setup-in-2026.md
+++ b/_drafts/my-python-setup-in-2026.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "My Python setup in 2026"
+tags   : [Python, Tooling]
+---
+
+uv, ruff, pyright. Why I stopped caring about pip and venv, and how a modern
+Python setup looks in practice.

--- a/_drafts/program-spotlight-cli-tools.md
+++ b/_drafts/program-spotlight-cli-tools.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "Program Spotlight: CLI tools I use daily"
+tags   : [software, CLI]
+---
+
+Part of the Program Spotlight series (following rclone and file managers). Covers
+fzf, ripgrep, tmux, zoxide, and bat.

--- a/_drafts/program-spotlight-paperless-ngx.md
+++ b/_drafts/program-spotlight-paperless-ngx.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "Program Spotlight: paperless-ngx"
+tags   : [software, Self-hosting]
+---
+
+Document management done right: OCR, tagging, and search. Part of the Program
+Spotlight series.

--- a/_drafts/python-data-work-without-jupyter.md
+++ b/_drafts/python-data-work-without-jupyter.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "Writing Python for data work without Jupyter"
+tags   : [Python, Data Science]
+---
+
+How to do data analysis in the terminal: scripts, Makefiles, and tooling that
+replace the notebook workflow.

--- a/_drafts/python-packages-beyond-pandas-numpy.md
+++ b/_drafts/python-packages-beyond-pandas-numpy.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "My top Python packages that aren't pandas or numpy"
+tags   : [Python, Data Science]
+---
+
+A personal list of the Python packages I reach for constantly that most people
+never hear about.

--- a/_drafts/quarto-vs-jupyter.md
+++ b/_drafts/quarto-vs-jupyter.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "Quarto for reproducible reports vs Jupyter"
+tags   : [Quarto, Jupyter, Reproducibility, Data Science]
+---
+
+Why text-based, version-control-friendly reports (Quarto) beat notebooks for
+serious work. Extends the earlier C++/org-mode notebook post.

--- a/_drafts/renv-vs-docker.md
+++ b/_drafts/renv-vs-docker.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "renv vs Docker: when to use each"
+tags   : [R, Docker, Reproducibility]
+---
+
+Compare package-level (renv) and environment-level (Docker) reproducibility, and
+give practical guidance on when each is the right choice.

--- a/_drafts/self-hosting-paperless-ngx.md
+++ b/_drafts/self-hosting-paperless-ngx.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "Self-hosting paperless-ngx as the start of leaving Big Tech"
+tags   : [Self-hosting, Privacy]
+---
+
+Paperless-ngx as a gateway into self-hosting: the setup, the payoff, and what
+came after.

--- a/_drafts/using-rss-and-why-its-good.md
+++ b/_drafts/using-rss-and-why-its-good.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "Using RSS and why it's good"
+tags   : [RSS, Web, Privacy]
+---
+
+Why RSS is still the best way to follow what matters, and how to set up a
+reader that actually fits your life.

--- a/_drafts/what-is-agentic-coding.md
+++ b/_drafts/what-is-agentic-coding.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "What agentic coding is, and what it is not"
+tags   : [AI, Software, Tooling]
+---
+
+A grounded introduction to agentic coding: what the tools actually do, their
+limits, and the hype vs. reality.

--- a/_drafts/why-i-keep-this-blog.md
+++ b/_drafts/why-i-keep-this-blog.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "Why I keep this blog"
+tags   : [Meta, Writing]
+---
+
+Reflections on running a small Jekyll blog on GitHub Pages: the writing
+pipeline, what I get out of it, and why I keep going.

--- a/_drafts/why-i-moved-my-r-workflow-to-python.md
+++ b/_drafts/why-i-moved-my-r-workflow-to-python.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "Why I moved my R workflow to Python"
+tags   : [R, Python, Data Science]
+---
+
+Follow-up to "R is a Terrible Programming Language". What drove the migration,
+what I kept in R, and how the transition went in practice.

--- a/_drafts/why-i-still-read-diffs.md
+++ b/_drafts/why-i-still-read-diffs.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "Why I still read the diffs my agent produces"
+tags   : [AI, Software, Tooling]
+---
+
+Agent-generated code still needs review. What I auto-accept, what I always
+rewrite, and how I keep my git hygiene intact.

--- a/_drafts/why-i-use-a-tiling-window-manager.md
+++ b/_drafts/why-i-use-a-tiling-window-manager.md
@@ -1,0 +1,8 @@
+---
+layout : post
+title  : "Why I use a tiling window manager"
+tags   : [Linux, WM]
+---
+
+The workflow and productivity argument for tiling window managers, based on my
+own daily setup.


### PR DESCRIPTION
Adds 22 placeholder drafts in `_drafts/` covering the planned article ideas discussed earlier (R follow-ups, Python, agentic coding, CLI spotlights, self-hosting, Firefox, personal/meta).

Drafts are intentionally stubs: front matter + one-line summary, ready to be expanded.