### PR TITLE
chore(site): exclude AGENTS.md from site build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,3 +54,4 @@ exclude:
   - vendor/gems/
   - vendor/ruby/
   - README.md
+  - AGENTS.md


### PR DESCRIPTION
Exclude AGENTS.md from the Jekyll build so agent instructions aren't served on the deployed site.