### PR TITLE
fix(article): set rclone article date to 10:00 today

### DIFF
--- a/_posts/2024-03-13-program-spotlight-rclone.md
+++ b/_posts/2024-03-13-program-spotlight-rclone.md
@@ -1,7 +1,7 @@
 ---
 layout : post
 title  : "Program Spotlight: Rclone"
-date   : 2026-08-15 19:13
+date   : 2026-08-15 10:00
 tags   : [Software, backup, cloud, photography]
 ---
 


### PR DESCRIPTION
## Why

Commit e68af84 (`fix/rclone-article-date`) changed the rclone article's front-matter `date` to `2026-08-15 19:13`, but the article disappeared from the published site.

The deploy log (run 31897880637) shows:

```
Reading: _posts/2024-03-13-program-spotlight-rclone.md
Skipping: _posts/2024-03-13-program-spotlight-rclone.md has a future date
```

### Root cause

- Jekyll parses front-matter dates with no timezone as **UTC**, so `2026-08-15 19:13` was treated as 19:13 UTC.
- GitHub Pages builds with `future: false`, while local builds default to `future: true` — which is why it rendered locally but not on the live site.
- At build time (17:17 UTC) the post was still in the future, so Jekyll silently skipped it.

## Fix

Set the date to `2026-08-15 10:00`, a time that has already passed, so the post is published on the next deploy.